### PR TITLE
Fix crash when error response body is not an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ async function refreshToken(argv) {
   await getToken(argv.server)
 }
 
-const extractMessage = o => ('message' in o) ? o : {message: JSON.stringify(o)}
+const extractMessage = o => (o && typeof o === 'object' && 'message' in o) ? o : {message: typeof o === 'string' ? o : JSON.stringify(o)}
 
 async function sendData(client, filename, options, expectedStatus) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

- `extractMessage` assumed `response.data` was always an object, causing a `TypeError: Cannot use 'in' operator to search for 'message' in <string>` when the server returns a plain string error (e.g. 403 Forbidden)
- Now handles plain strings directly and falls back to `JSON.stringify` for other non-object types

## Test plan

- [x] Reproduce: run `update-patch` against a server without the accept-patch permission change — previously crashes, now shows the error message cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)